### PR TITLE
Use `floor` instead of `trunc` to handle cases when the minimum value is a negative decimal number with more than 3 decimals

### DIFF
--- a/R/module-filterData.R
+++ b/R/module-filterData.R
@@ -270,7 +270,7 @@ naInput <- function(key, var, ns) {
 
 range_val <- function(x) {
   y <- round(x, 2)
-  y[1] <- trunc(x[1]*1000)/1000
+  y[1] <- floor(x[1]*1000)/1000
   y[length(y)] <- ceiling(x[length(x)]*1000)/1000
   return(y)
 }


### PR DESCRIPTION
Small example : 

```r
library(tidyverse)
library(esquisse)

df <- data.frame(sexe = c("H","F"),
                 mean = c(-0.3284, 1))

esquisse::esquisser(df)
```

When producing a bar plot with `sexe` as `x` and `mean` as `y`, the -0.3284 value is filtered out.

The resulting ggplot2 code is right, and the graph is correct when the code is run in the console :

```r
ggplot(data = df) +
  aes(x = sexe, weight = mean) +
  geom_bar(fill = '#0c4c8a') +
  theme_minimal()
```

I think this happens because the smallest value computed for the numeric range control to filter data is 
greater than the minimum data value when the latter is a negative decimal number with more than 3 decimal numbers. In this example, the computed smallest value is -0.328 instead of -0.329.

It seems that using `floor` instead of `trunc` in the smallest value computation fixes the problem.