### PR TITLE
Prevent some encoding crash...?

### DIFF
--- a/R/module-filterDF.R
+++ b/R/module-filterDF.R
@@ -209,7 +209,7 @@ create_filters <- function(data, vars = NULL,
         )
       } else {
         values <- unique(as.character(var))
-        values <- values[trimws(values) != ""]
+        values <- tryCatch(values[trimws(values) != ""], error = function(e) values)
         if (isTRUE(picker)) {
           tags$div(
             style = "position: relative;",
@@ -401,7 +401,7 @@ drop_id <- function(data) {
     FUN = function(x) {
       if (inherits(x, c("factor", "character"))) {
         values <- unique(as.character(x))
-        values <- values[trimws(values) != ""]
+        values <- tryCatch(values[trimws(values) != ""], error = function(e) values)
         if (length(values) <= 1)
           return(NULL)
         if (length(values) >= length(x) * 0.9)


### PR DESCRIPTION
Hi Victor, 

If data have some bad encoding like this example in line 3 : 

````
    CTP_ID_YEAR             CTP_NAME   Type2
 1:        2011 MUSTASAARIN KAUPUNKI Finland
 2:        2015        KALMAR KOMMUN  Sweden
 3:        2015 SKELLEFTE<c5> KOMMUN  Sweden
 4:        2015         VAXJO KOMMUN  Sweden
 5:        2008        MJOLBY KOMMUN  Sweden
 6:        2008           ARE KOMMUN  Sweden
````

``create_filters`` using ``trimws`` crash and so the module / app "ll be dead ! So I propose this really quick fix. Not sur it's the best but it's work...

Benoit