### PR TITLE
prevent encoding bug + disable_filters bug ?

### DIFF
--- a/R/esquisser.R
+++ b/R/esquisser.R
@@ -68,7 +68,7 @@ esquisser <- function(data = NULL,
   }
 
   runGadget(
-    app = esquisserUI(id = "esquisse", container = NULL, insert_code = TRUE), 
+    app = esquisserUI(id = "esquisse", container = NULL, insert_code = TRUE, disable_filters = disable_filters), 
     server = function(input, output, session) {
       callModule(
         module = esquisserServer, 

--- a/R/module-chartControls.R
+++ b/R/module-chartControls.R
@@ -385,8 +385,10 @@ chartControlsServer <- function(input, output, session,
   })
   
   observeEvent(output_filter$data_filtered(), {
-    outin$data <- output_filter$data_filtered()
-    outin$code <- output_filter$code
+    if(nrow(output_filter$data_filtered()) > 0){
+      outin$data <- output_filter$data_filtered()
+      outin$code <- output_filter$code
+    }
   })
 
   return(outin)

--- a/R/module-filterDF.R
+++ b/R/module-filterDF.R
@@ -209,7 +209,10 @@ create_filters <- function(data, vars = NULL,
         )
       } else {
         values <- unique(as.character(var))
-        values <- tryCatch(values[trimws(values) != ""], error = function(e) values)
+        values <- tryCatch(values[trimws(values) != ""], error = function(e){
+          Encoding(values[!validEnc(values)]) <- "unknown"
+          values
+        })
         if (isTRUE(picker)) {
           tags$div(
             style = "position: relative;",
@@ -401,7 +404,10 @@ drop_id <- function(data) {
     FUN = function(x) {
       if (inherits(x, c("factor", "character"))) {
         values <- unique(as.character(x))
-        values <- tryCatch(values[trimws(values) != ""], error = function(e) values)
+        values <- tryCatch(values[trimws(values) != ""], error = function(e){
+          Encoding(values[!validEnc(values)]) <- "unknown"
+          values
+        })
         if (length(values) <= 1)
           return(NULL)
         if (length(values) >= length(x) * 0.9)


### PR DESCRIPTION
Hi Victor,

Same problem as previous merge request, but with better treatment. Some others case crashed with the previous patch...
If data have some bad encoding like this example in line 3 :

    CTP_ID_YEAR             CTP_NAME   Type2
 1:        2011 MUSTASAARIN KAUPUNKI Finland
 2:        2015        KALMAR KOMMUN  Sweden
 3:        2015 SKELLEFTE<c5> KOMMUN  Sweden
 4:        2015         VAXJO KOMMUN  Sweden
 5:        2008        MJOLBY KOMMUN  Sweden
 6:        2008           ARE KOMMUN  Sweden
create_filters using trimws crash and so the module / app "ll be dead ! So I propose this really quick fix. Not sur it's the best but it's work...

Moreover, it's seems there is some bug with disable_filters : 

- options not passing from ``esquisser`` to ``esquisserUI``
- without filter (``disable_filters = TRUE``), not data !

I 've just write a (really) quick working patch....

Benoit