### PR TITLE
check if data is null

### DIFF
--- a/R/esquisserServer.R
+++ b/R/esquisserServer.R
@@ -7,7 +7,7 @@
 #' @param sizeDataModule Size for the modal window for selecting data.
 #'
 #' @export
-#' 
+#'
 #' @rdname module-esquisse
 #'
 #' @importFrom shiny callModule reactiveValues observeEvent renderPrint
@@ -16,16 +16,16 @@
 #' @importFrom rlang expr_deparse
 #'
 esquisserServer <- function(input, output, session, data = NULL, dataModule = c("GlobalEnv", "ImportFile"), sizeDataModule = "m") {
-  
+
   ggplotCall <- reactiveValues(code = "")
-  
+
   observeEvent(data$data, {
     dataChart$data <- data$data
     dataChart$name <- data$name
   }, ignoreInit = FALSE)
 
   dataChart <- callModule(
-    module = chooseDataServer, 
+    module = chooseDataServer,
     id = "choose-data",
     data = isolate(data$data),
     name = isolate(data$name),
@@ -37,14 +37,14 @@ esquisserServer <- function(input, output, session, data = NULL, dataModule = c(
     # special case: geom_sf
     if (inherits(dataChart$data, what = "sf")) {
       geom_possible$x <- c("sf", geom_possible$x)
-    } 
+    }
     var_choices <- setdiff(names(dataChart$data), attr(dataChart$data, "sf_column"))
     updateDragulaInput(
-      session = session, 
+      session = session,
       inputId = "dragvars", status = NULL,
-      choiceValues = var_choices, 
+      choiceValues = var_choices,
       choiceNames = badgeType(
-        col_name = var_choices, 
+        col_name = var_choices,
         col_type = col_type(dataChart$data[, var_choices])
       ),
       badge = FALSE
@@ -54,25 +54,31 @@ esquisserServer <- function(input, output, session, data = NULL, dataModule = c(
   geom_possible <- reactiveValues(x = "auto")
   geom_controls <- reactiveValues(x = "auto")
   observeEvent(list(input$dragvars$target, input$geom), {
+    if (is.null(dataChart$data)) {
+      shiny::showNotification(ui = "No Dataset selected",
+                              type = "warning", session = session)
+      req(F)
+    }
+
     geoms <- potential_geoms(
       data = dataChart$data,
       mapping = build_aes(
         data = dataChart$data,
-        x = input$dragvars$target$xvar, 
+        x = input$dragvars$target$xvar,
         y = input$dragvars$target$yvar
       )
     )
     geom_possible$x <- c("auto", geoms)
 
     geom_controls$x <- select_geom_controls(input$geom, geoms)
-    
+
     if (!is.null(input$dragvars$target$fill) | !is.null(input$dragvars$target$color)) {
       geom_controls$palette <- TRUE
     } else {
       geom_controls$palette <- FALSE
     }
   })
-  
+
   observeEvent(geom_possible$x, {
     geoms <- c(
       "auto", "line", "area", "bar", "histogram",
@@ -90,9 +96,9 @@ esquisserServer <- function(input, output, session, data = NULL, dataModule = c(
   # Module chart controls : title, xlabs, colors, export...
   paramsChart <- reactiveValues(inputs = NULL)
   paramsChart <- callModule(
-    module = chartControlsServer, 
-    id = "controls", 
-    type = geom_controls, 
+    module = chartControlsServer,
+    id = "controls",
+    type = geom_controls,
     data_table = reactive(dataChart$data),
     data_name = reactive({
       req(dataChart$name)
@@ -124,46 +130,46 @@ esquisserServer <- function(input, output, session, data = NULL, dataModule = c(
     })
   )
 
-  
+
   output$plooooooot <- renderPlot({
     req(input$play_plot, cancelOutput = TRUE)
     req(dataChart$data)
     req(paramsChart$data)
     req(paramsChart$inputs)
     req(input$geom)
-    
+
     aes_input <- make_aes(input$dragvars$target)
 
     req(unlist(aes_input) %in% names(dataChart$data))
-    
+
     mapping <- build_aes(
       data = dataChart$data,
-      .list = aes_input, 
+      .list = aes_input,
       geom = input$geom
     )
-    
+
     geoms <- potential_geoms(
       data = dataChart$data,
       mapping = mapping
     )
     req(input$geom %in% geoms)
-    
+
     data <- paramsChart$data
-    
+
     scales <- which_pal_scale(
       mapping = mapping,
       palette = paramsChart$inputs$palette,
       data = data
     )
-    
+
     if (identical(input$geom, "auto")) {
       geom <- "blank"
     } else {
       geom <- input$geom
     }
-    
+
     geom_args <- match_geom_args(input$geom, paramsChart$inputs, mapping = mapping)
-    
+
     if (isTRUE(paramsChart$smooth$add) & input$geom %in% c("point", "line")) {
       geom <- c(geom, "smooth")
       geom_args <- c(
@@ -171,7 +177,7 @@ esquisserServer <- function(input, output, session, data = NULL, dataModule = c(
         list(smooth = paramsChart$smooth$args)
       )
     }
-    
+
     scales_args <- scales$args
     scales <- scales$scales
 
@@ -179,32 +185,32 @@ esquisserServer <- function(input, output, session, data = NULL, dataModule = c(
       scales <- c(scales, "x_continuous")
       scales_args <- c(scales_args, list(x_continuous = paramsChart$transX$args))
     }
-    
+
     if (isTRUE(paramsChart$transY$use)) {
       scales <- c(scales, "y_continuous")
       scales_args <- c(scales_args, list(y_continuous = paramsChart$transY$args))
     }
-    
+
     gg_call <- ggcall(
-      data = dataChart$name, 
-      mapping = mapping, 
+      data = dataChart$name,
+      mapping = mapping,
       geom = geom,
-      geom_args = geom_args, 
-      scales = scales, 
+      geom_args = geom_args,
+      scales = scales,
       scales_args = scales_args,
-      labs = paramsChart$labs, 
+      labs = paramsChart$labs,
       theme = paramsChart$theme$theme,
-      theme_args = paramsChart$theme$args, 
-      coord = paramsChart$coord, 
-      facet = input$dragvars$target$facet, 
+      theme_args = paramsChart$theme$args,
+      coord = paramsChart$coord,
+      facet = input$dragvars$target$facet,
       facet_args = paramsChart$facet
     )
 
     ggplotCall$code <- expr_deparse(gg_call, width = 1e4)
     ggplotCall$call <- gg_call
-    
+
     ggplotCall$ggobj <- safe_ggplot(
-      expr = gg_call, 
+      expr = gg_call,
       data = setNames(list(data), dataChart$name)
     )
     ggplotCall$ggobj$plot


### PR DESCRIPTION
Opening the `Select a dataset` modal and closing it again without selecting a dataset, crashed the app when one of the variables is dragged into the x/y/fill,... fields.

This PR includes a small check if the dataset is NULL and shows a warning notification. 
Maybe it would make sense to remove the variables instead, if no dataset is selected, then this error should not happen. 